### PR TITLE
김성연 1주차 스택

### DIFF
--- a/seongyeon/src/week01/boj16815/Main.java
+++ b/seongyeon/src/week01/boj16815/Main.java
@@ -1,7 +1,39 @@
 package week01.boj16815;
 
-public class Main {
-    public static void main(String[] args) {
+import java.io.*;
+import java.util.*;
 
+/**
+ *  문제: Star in Parentheses (실버5)
+ *  메모리: 14192 KB
+ *  시간: 124 ms
+ */
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        String s = reader.readLine();
+
+        System.out.print(solution(s));
+    }
+
+    public static int solution(String s) {
+        Stack<Character> stack = new Stack<>();
+
+        for (char c : s.toCharArray()) {
+            if (c == '*') {
+                break;
+            }
+
+            if (c == '(') {
+                stack.push(c);
+            }
+
+            if (c == ')' & !stack.empty()) {
+                stack.pop();
+            }
+        }
+
+        return stack.size();
     }
 }

--- a/seongyeon/src/week01/boj17413/Main.java
+++ b/seongyeon/src/week01/boj17413/Main.java
@@ -1,7 +1,60 @@
 package week01.boj17413;
 
-public class Main {
-    public static void main(String[] args) {
+import java.io.*;
+import java.util.*;
 
+/**
+ * 문제: 단어 뒤집기 2 (실버 3)
+ * 메모리 23484 kb
+ * 시간 240 ms
+ */
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(System.in));
+        String s = reader.readLine();
+
+        System.out.print(solution(s));
+    }
+
+    public static StringBuilder solution(String s) {
+        Stack<Character> stack = new Stack<>();
+        boolean tagOpenFlag = false;
+        StringBuilder result = new StringBuilder();
+
+        for (char ch : s.toCharArray()) {
+            if (ch == '<') {
+                popAll(stack, result);
+                tagOpenFlag = true;
+                result.append(ch);
+                continue;
+            }
+            else if (ch == '>') {
+                tagOpenFlag = false;
+                result.append(ch);
+                continue;
+            }
+
+            if (ch == ' ' & !tagOpenFlag) {
+                popAll(stack, result);
+                result.append(ch);
+                continue;
+            }
+
+            if (tagOpenFlag) {
+                result.append(ch);
+                continue;
+            }
+            stack.push(ch);
+        }
+        popAll(stack, result);
+        return result;
+    }
+
+    private static void popAll(Stack<Character> stack, StringBuilder result) {
+        while (!stack.empty()) {
+            result.append(stack.pop());
+        }
     }
 }

--- a/seongyeon/src/week01/pgs12906/Main.java
+++ b/seongyeon/src/week01/pgs12906/Main.java
@@ -1,7 +1,22 @@
 package week01.pgs12906;
 
-public class Main {
-    public static void main(String[] args) {
+import java.util.*;
 
+/**
+ * 문제: 같은 숫자는 싫어
+ */
+
+public class Main {
+
+    public int[] solution(int[] arr) {
+        Stack<Integer> stack = new Stack<>();
+
+        for (int num : arr) {
+            if (stack.empty() || stack.peek() != num) {
+                stack.push(num);
+            }
+        }
+
+        return stack.stream().mapToInt(Integer::intValue).toArray();
     }
 }

--- a/seongyeon/src/week01/pgs42586/Main.java
+++ b/seongyeon/src/week01/pgs42586/Main.java
@@ -1,7 +1,41 @@
 package week01.pgs42586;
 
-public class Main {
-    public static void main(String[] args) {
+import java.util.*;
 
+/**
+ * 문제: 기능개발
+ */
+
+public class Main {
+
+    public int[] solution(int[] progresses, int[] speeds) {
+        Queue<Integer> queue = new LinkedList<>();
+
+        for (int i = 0; i < progresses.length; i++) {
+            int rest = (int) Math.ceil((100.0 - progresses[i]) / speeds[i]);
+            queue.offer(rest);
+        }
+
+        int count = 0;
+        int maxProgress = queue.peek();
+        List<Integer> result = new ArrayList<>();
+
+        while (!queue.isEmpty()) {
+            int currentProgress = queue.poll();
+            if (currentProgress <= maxProgress) {
+                count++;
+                continue;
+            }
+
+            result.add(count);
+            count = 1;
+            maxProgress = currentProgress;
+        }
+
+        if (count != 0) {
+            result.add(count);
+        }
+
+        return result.stream().mapToInt(Integer::intValue).toArray();
     }
 }


### PR DESCRIPTION
안녕하세요 오랜만에 자바로 문제를 풀었더니 익숙하지가 않네요..😅
그래도 열심히 풀어봤습니다 ㅎㅎ 

## 백준 16815: Star in Parentheses

- 풀이: 문제에서 주어지는 입력이 완벽한 괄호라는 것을 보고 * 이전에 나오는 짝이 없는 '(' 의 수를 세는 방법으로 해결

 1. `*` 를 브레이크 포인트로 잡는다.
 2. stack을 이용해서 `)`가 나오면 가장 최근 `(`를 제거한다. 
 3. stack에 남아있는 `(` 수를 확인한다.

  
## 백준 17413: 단어 뒤집기 2
- 풀이: tag에 해당하지 않는 문자열들을 stack에 넣고, `' '` 가 등장하면 stack에서 뽑아내는 방법으로 해결

1. `<` 가 나오면 `tagOpenFlag`를 `true`로 설정하고, 이후 나오는 문자열을 스택에 넣지 않도록 한다.
2. `>`가 나오면 `tagOpenFlag`를 `false`로 설정하고, 이후 나오는 문자열을 스택에 넣도록 한다.
3. `' '`가 나오고 `tagOpenFlag`가 `false`면 stack의 값들을 모두 꺼낸다.
    - `tagOpenFlag`를 확인하는 이유는 태그 내부에 `' '` 가 위치할 수 있기 때문이다.


## 프로그래머스 12906: 같은 숫자는 싫어
- 풀이: 이전 수와 비교하며 동일하지 않은 수들을 찾습니다.
(stack에 마지막으로 들어간 수와 비교해서 다르면 stack에 넣는다)

- 관련 코멘트: 카테고리가 스택이라는 이유로 스택을 사용하려고 고민을 많이 했는데, 이 문제에서 스택을 사용했을 때의 이점은 잘 모르겠습니다. 일단 사용해서 풀긴 했으나, 리스트와 인덱스만을 이용해서 풀 수 있을 것 같아서요.


## 프로그래머스 42586: 기능개발
- 풀이: 남은 작업 시간들을 계산하고, 앞서 등장하는 작업 시간보다 같거나 작은 것들을 세어가는 방법으로 해결

1. `progresses`와 `speeds`를 이용하여 남은 작업 시간을 계산하여 큐에 넣는다.
2. 큐에서 하나씩 꺼내가며 작업 시간을 비교한다.
    - 작업시간이 같거나 작다면 count 를 증가시킨다.
    - 작업시간이 더 크다면, 결과 리스트에 추가한 후 해당 작업 시간을 기준 작업 시간으로 설정하고, count 를 초기화 시킨다.

- 관련 코멘트: 이번 주제가 스택이라 스택으로 어떻게 풀 수 있을지 고민을 하다가, 오히려 큐로 풀기 좋은 문제 인 것 같다는 느낌이 들어서 큐로 풀었습니다. 물론 작업 시간을 반대로 넣고 빼면 스택으로 풀 수 있겠지만, 약간 그렇게 풀면 카테고리에 맞춰서 푸는 기분이 들어서요.. 스택으로 푸신 분들 코드 보고 배워야할 것 같습니다😅
